### PR TITLE
Adds .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: lavender
+  name: lavender
+  description: "Lavender: The slightly more compromising Python code formatter"
+  entry: lavender
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [python]


### PR DESCRIPTION
Adapted directly from [the Black version](https://github.com/psf/black/blob/master/.pre-commit-hooks.yaml), this will make it easier to use Lavender with [the Pre-Commit framework.](https://pre-commit.com/)